### PR TITLE
Fix role check

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ def check_super_perms(message):
 
     See config file [Perms]."""
     has_super_role = any(
-        True for role in message.author.roles if role in SUPER_ROLES)
+        True for role in message.author.roles if role.name in SUPER_ROLES)
     return message.author.id in SUPER_USERS or has_super_role
 
 


### PR DESCRIPTION
Old code causes role checks to always fail because comparisons were done using the role object instead of the role name.